### PR TITLE
Code cleanup, add support for ScanNet and HM3D in OpenEQA format

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,20 +331,17 @@ PKL_FILENAME=output.pkl.gz  # Change this to the actual output file name of the 
 python scenegraph/build_scenegraph_cfslam.py \
     --mode extract-node-captions \
     --cachedir ${REPLICA_ROOT}/${SCENE_NAME}/sg_cache \
-    --mapfile ${REPLICA_ROOT}/${SCENE_NAME}/pcd_saves/${PKL_FILENAME} \
-    --class_names_file ${REPLICA_ROOT}/${SCENE_NAME}/gsa_classes_ram_withbg_allclasses.json
+    --mapfile ${REPLICA_ROOT}/${SCENE_NAME}/pcd_saves/${PKL_FILENAME}
 
 python scenegraph/build_scenegraph_cfslam.py \
     --mode refine-node-captions \
     --cachedir ${REPLICA_ROOT}/${SCENE_NAME}/sg_cache \
-    --mapfile ${REPLICA_ROOT}/${SCENE_NAME}/pcd_saves/${PKL_FILENAME} \
-    --class_names_file ${REPLICA_ROOT}/${SCENE_NAME}/gsa_classes_ram_withbg_allclasses.json
+    --mapfile ${REPLICA_ROOT}/${SCENE_NAME}/pcd_saves/${PKL_FILENAME}
 
 python scenegraph/build_scenegraph_cfslam.py \
     --mode build-scenegraph \
     --cachedir ${REPLICA_ROOT}/${SCENE_NAME}/sg_cache \
-    --mapfile ${REPLICA_ROOT}/${SCENE_NAME}/pcd_saves/${PKL_FILENAME} \
-    --class_names_file ${REPLICA_ROOT}/${SCENE_NAME}/gsa_classes_ram_withbg_allclasses.json
+    --mapfile ${REPLICA_ROOT}/${SCENE_NAME}/pcd_saves/${PKL_FILENAME}
 ```
 
 Then the object map with scene graph can be visualized using the following command. 

--- a/conceptgraph/dataset/dataconfigs/hm3d-openeqa.yaml
+++ b/conceptgraph/dataset/dataconfigs/hm3d-openeqa.yaml
@@ -1,0 +1,9 @@
+dataset_name: 'hm3d-openeqa'
+camera_params:
+  image_height: 1080
+  image_width: 1920
+  fx: 0 # To be overwritten
+  fy: 0
+  cx: 0
+  cy: 0
+  png_depth_scale: 6553.5

--- a/conceptgraph/dataset/dataconfigs/scannet/base.yaml
+++ b/conceptgraph/dataset/dataconfigs/scannet/base.yaml
@@ -2,8 +2,8 @@ dataset_name: 'scannet'
 camera_params:
   image_height: 968
   image_width: 1296
-  fx: 1169.621094
-  fy: 1167.105103
-  cx: 646.295044
-  cy: 489.927032
+  fx: 0.0  # To be loaded from the instrinsic files in ScanNet dataset
+  fy: 0.0
+  cx: 0.0
+  cy: 0.0
   png_depth_scale: 1000.0 #for depth image in png format

--- a/conceptgraph/dataset/dataconfigs/scannet/scene0011_00.yaml
+++ b/conceptgraph/dataset/dataconfigs/scannet/scene0011_00.yaml
@@ -1,9 +1,0 @@
-dataset_name: 'scannet'
-camera_params:
-  image_height: 968
-  image_width: 1296
-  fx: 1169.621094
-  fy: 1167.105103
-  cx: 646.295044
-  cy: 489.927032
-  png_depth_scale: 1000.0 #for depth image in png format

--- a/conceptgraph/dataset/dataconfigs/scannet/scene0021_00.yaml
+++ b/conceptgraph/dataset/dataconfigs/scannet/scene0021_00.yaml
@@ -1,9 +1,0 @@
-dataset_name: 'scannet'
-camera_params:
-  image_height: 968
-  image_width: 1296
-  fx: 1170.187988
-  fy: 1170.187988
-  cx: 647.750000
-  cy: 483.750000
-  png_depth_scale: 1000.0 #for depth image in png format

--- a/conceptgraph/dataset/dataconfigs/scannet/scene0050_00.yaml
+++ b/conceptgraph/dataset/dataconfigs/scannet/scene0050_00.yaml
@@ -1,9 +1,0 @@
-dataset_name: 'scannet'
-camera_params:
-  image_height: 968
-  image_width: 1296
-  fx: 1170.187988
-  fy: 1170.187988
-  cx: 647.750000
-  cy: 483.750000
-  png_depth_scale: 1000.0 #for depth image in png format

--- a/conceptgraph/dataset/dataconfigs/scannet/scene0051_03.yaml
+++ b/conceptgraph/dataset/dataconfigs/scannet/scene0051_03.yaml
@@ -1,9 +1,0 @@
-dataset_name: 'scannet'
-camera_params:
-  image_height: 968
-  image_width: 1296
-  fx: 1170.187988
-  fy: 1170.187988
-  cx: 647.750000
-  cy: 483.750000
-  png_depth_scale: 1000.0 #for depth image in png format

--- a/conceptgraph/dataset/dataconfigs/scannet/scene0132_02.yaml
+++ b/conceptgraph/dataset/dataconfigs/scannet/scene0132_02.yaml
@@ -1,9 +1,0 @@
-dataset_name: 'scannet'
-camera_params:
-  image_height: 968
-  image_width: 1296
-  fx: 1170.187988
-  fy: 1170.187988
-  cx: 647.750000
-  cy: 483.750000
-  png_depth_scale: 1000.0 #for depth image in png format

--- a/conceptgraph/dataset/dataconfigs/scannet/scene0211_00.yaml
+++ b/conceptgraph/dataset/dataconfigs/scannet/scene0211_00.yaml
@@ -1,9 +1,0 @@
-dataset_name: 'scannet'
-camera_params:
-  image_height: 968
-  image_width: 1296
-  fx: 1163.445068
-  fy: 1164.793945
-  cx: 653.626038
-  cy: 481.600037
-  png_depth_scale: 1000.0 #for depth image in png format

--- a/conceptgraph/dataset/dataconfigs/scannet/scene0343_00.yaml
+++ b/conceptgraph/dataset/dataconfigs/scannet/scene0343_00.yaml
@@ -1,9 +1,0 @@
-dataset_name: 'scannet'
-camera_params:
-  image_height: 968
-  image_width: 1296
-  fx: 1170.187988
-  fy: 1170.187988
-  cx: 647.750000
-  cy: 483.750000
-  png_depth_scale: 1000.0 #for depth image in png format

--- a/conceptgraph/dataset/datasets_common.py
+++ b/conceptgraph/dataset/datasets_common.py
@@ -500,6 +500,15 @@ class ScannetDataset(GradSLAMDataset):
     ):
         self.input_folder = os.path.join(basedir, sequence)
         self.pose_path = None
+
+        # Load the intrinsic matrix from the file in each scene
+        scene_intrinsic_path = os.path.join(self.input_folder, "intrinsic", "intrinsic_color.txt")
+        scene_intrinsic = np.loadtxt(scene_intrinsic_path)
+        config_dict['camera_params']['fx'] = scene_intrinsic[0, 0]
+        config_dict['camera_params']['fy'] = scene_intrinsic[1, 1]
+        config_dict['camera_params']['cx'] = scene_intrinsic[0, 2]
+        config_dict['camera_params']['cy'] = scene_intrinsic[1, 2]
+        
         super().__init__(
             config_dict,
             stride=stride,
@@ -1001,7 +1010,76 @@ class Hm3dDataset(GradSLAMDataset):
             poses.append(pose)
             
         return poses
+    
+class Hm3dOpeneqaDataset(GradSLAMDataset):
+    def __init__(
+        self,
+        config_dict,
+        basedir,
+        sequence,
+        stride: Optional[int] = None,
+        start: Optional[int] = 0,
+        end: Optional[int] = -1,
+        desired_height: Optional[int] = 480,
+        desired_width: Optional[int] = 640,
+        load_embeddings: Optional[bool] = False,
+        embedding_dir: Optional[str] = "embeddings",
+        embedding_dim: Optional[int] = 512,
+        **kwargs,
+    ):
+        self.input_folder = os.path.join(basedir, sequence)
+        self.pose_path = None
 
+        # Load the intrinsic matrix from the file in each scene
+        scene_intrinsic_path = os.path.join(self.input_folder, "intrinsic_color.txt")
+        scene_intrinsic = np.loadtxt(scene_intrinsic_path)
+        config_dict['camera_params']['fx'] = scene_intrinsic[0, 0]
+        config_dict['camera_params']['fy'] = scene_intrinsic[1, 1]
+        config_dict['camera_params']['cx'] = scene_intrinsic[0, 2]
+        config_dict['camera_params']['cy'] = scene_intrinsic[1, 2]
+        
+        super().__init__(
+            config_dict,
+            stride=stride,
+            start=start,
+            end=end,
+            desired_height=desired_height,
+            desired_width=desired_width,
+            load_embeddings=load_embeddings,
+            embedding_dir=embedding_dir,
+            embedding_dim=embedding_dim,
+            **kwargs,
+        )
+        
+    def get_filepaths(self):
+        color_paths = natsorted(glob.glob(f"{self.input_folder}/*-rgb.png"))
+        depth_paths = natsorted(glob.glob(f"{self.input_folder}/*-depth.png"))
+        embedding_paths = None
+        if self.load_embeddings:
+            embedding_paths = natsorted(
+                glob.glob(f"{self.input_folder}/{self.embedding_dir}/*.pt")
+            )
+        return color_paths, depth_paths, embedding_paths
+    
+    def load_poses(self):
+        poses = []
+        posefiles = natsorted(glob.glob(f"{self.input_folder}/[0-9]*.txt"))
+
+        P = torch.tensor(
+            [
+                [1, 0, 0, 0],
+                [0, -1, 0, 0],
+                [0, 0, -1, 0],
+                [0, 0, 0, 1]
+            ]
+        ).float()
+        
+        for posefile in posefiles:
+            pose = torch.from_numpy(np.loadtxt(posefile)).float()
+            pose = P @ pose @ P.T
+            poses.append(pose)
+        return poses
+        
 def load_dataset_config(path, default_path=None):
     """
     Loads config file.
@@ -1107,6 +1185,8 @@ def get_dataset(dataconfig, basedir, sequence, **kwargs):
         return MultiscanDataset(config_dict, basedir, sequence, **kwargs)
     elif config_dict['dataset_name'].lower() in ['hm3d']:
         return Hm3dDataset(config_dict, basedir, sequence, **kwargs)
+    elif config_dict['dataset_name'].lower() in ['hm3d-openeqa']:
+        return Hm3dOpeneqaDataset(config_dict, basedir, sequence, **kwargs)
     else:
         raise ValueError(f"Unknown dataset name {config_dict['dataset_name']}")
 

--- a/conceptgraph/scripts/generate_gsa_results.py
+++ b/conceptgraph/scripts/generate_gsa_results.py
@@ -20,7 +20,6 @@ import pickle
 import gzip
 import open_clip
 
-from ultralytics import YOLO
 import torch
 import torchvision
 from torch.utils.data import Dataset
@@ -102,8 +101,8 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument("--end", type=int, default=-1)
     parser.add_argument("--stride", type=int, default=1)
 
-    parser.add_argument("--desired-height", type=int, default=480)
-    parser.add_argument("--desired-width", type=int, default=640)
+    parser.add_argument("--desired_height", type=int, default=480)
+    parser.add_argument("--desired_width", type=int, default=640)
 
     parser.add_argument("--box_threshold", type=float, default=0.25)
     parser.add_argument("--text_threshold", type=float, default=0.25)
@@ -341,7 +340,9 @@ def main(args: argparse.Namespace):
     global_classes = set()
     
     # Initialize a YOLO-World model
-    yolo_model_w_classes = YOLO('yolov8l-world.pt')  # or choose yolov8m/l-world.pt
+    if args.detector == "yolo":
+        from ultralytics import YOLO
+        yolo_model_w_classes = YOLO('yolov8l-world.pt')  # or choose yolov8m/l-world.pt
     
     if args.class_set == "scene":
         # Load the object meta information
@@ -421,8 +422,8 @@ def main(args: argparse.Namespace):
 
         color_path = Path(color_path)
         
-        vis_save_path = color_path.parent.parent / f"gsa_vis_{save_name}" / color_path.name
-        detections_save_path = color_path.parent.parent / f"gsa_detections_{save_name}" / color_path.name
+        vis_save_path = args.dataset_root / args.scene_id / f"gsa_vis_{save_name}" / color_path.name
+        detections_save_path = args.dataset_root / args.scene_id / f"gsa_detections_{save_name}" / color_path.name
         detections_save_path = detections_save_path.with_suffix(".pkl.gz")
         
         os.makedirs(os.path.dirname(vis_save_path), exist_ok=True)
@@ -461,7 +462,7 @@ def main(args: argparse.Namespace):
                 "room", "kitchen", "office", "house", "home", "building", "corner",
                 "shadow", "carpet", "photo", "shade", "stall", "space", "aquarium", 
                 "apartment", "image", "city", "blue", "skylight", "hallway", 
-                "bureau", "modern", "salon", "doorway", "wall lamp"
+                "bureau", "modern", "salon", "doorway", "wall lamp", "wood floor"
             ]
             bg_classes = ["wall", "floor", "ceiling"]
 

--- a/conceptgraph/slam/cfslam_pipeline_batch.py
+++ b/conceptgraph/slam/cfslam_pipeline_batch.py
@@ -187,7 +187,7 @@ def main(cfg : DictConfig):
         gobs = None # stands for grounded SAM observations
 
         color_path = Path(color_path)
-        detections_path = color_path.parent.parent / cfg.detection_folder_name / color_path.name
+        detections_path = cfg.dataset_root / cfg.scene_id / cfg.detection_folder_name / color_path.name
         detections_path = detections_path.with_suffix(".pkl.gz")
         color_path = str(color_path)
         detections_path = str(detections_path)

--- a/conceptgraph/utils/model_utils.py
+++ b/conceptgraph/utils/model_utils.py
@@ -1,6 +1,5 @@
 import os
 from conceptgraph.utils.general_utils import measure_time
-from line_profiler import profile
 from segment_anything import sam_model_registry, SamPredictor, SamAutomaticMaskGenerator
 import numpy as np
 import torch
@@ -129,7 +128,6 @@ def compute_clip_features(image, detections, clip_model, clip_preprocess, clip_t
 
     return image_crops, image_feats, text_feats
 
-@profile
 def compute_clip_features_batched(image, detections, clip_model, clip_preprocess, clip_tokenizer, classes, device):
     
     image = Image.fromarray(image)


### PR DESCRIPTION
- Remove the unused `--mapfile` argument. 
- Always load intrinsics, rather than use a predefined one for ScanNet. 
- Add support for HM3D sequences generated by OpenEQA. 
- Removed some unused imports and got a better structure. 